### PR TITLE
upload and overwrite checkpoints to wandb

### DIFF
--- a/config/worker/vae_worker.yaml
+++ b/config/worker/vae_worker.yaml
@@ -3,6 +3,7 @@ worker_class: VAE_Worker
 worker:
   epoch_save_freq: 50
   log_interval: 50
+  upload_checkpoints: true
   annealing_temp: 1e-4
   max_beta: 1.0
   optim_class: Adam


### PR DESCRIPTION
Added some logic to `AbstractWorker.save` that will upload checkpoints if wandb is enabled, if it's a `'latest'` or `'best'` checkpoint, and if the `upload_checkpoints` arg in worker config is set to `true`. The checkpoints appear in the Files section of the wandb run, and can either be manually downloaded from the web interface, or accessed via python library with `wandb.restore`.

We can add the `restore` functionality later, for resuming runs on new machines or pre-emptible instances, etc.

I am using [pathlib](https://docs.python.org/3/library/pathlib.html) to get the parent of the run directory, we should probably move the rest of the path/directory handling in PopGen over to pathlib eventually.